### PR TITLE
Reduce archive size by excluding tests

### DIFF
--- a/drupal-src/.gitattributes
+++ b/drupal-src/.gitattributes
@@ -65,4 +65,8 @@ core/.phpstan-baseline.php text eol=lf whitespace=blank-at-eol,-blank-at-eof,-sp
 
 patches export-ignore
 vendor/bin export-ignore
+web/core/tests/**/* export-ignore
+web/core/modules/*/tests/**/* export-ignore
+web/core/themes/*/tests/**/* export-ignore
 web/sites/default/files/php export-ignore
+web/core/assets export-ignore

--- a/drupal-src/composer.lock
+++ b/drupal-src/composer.lock
@@ -2373,16 +2373,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.2",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
@@ -2393,7 +2393,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -2425,9 +2425,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "pear/archive_tar",

--- a/drupal-src/patches/.gitattributes
+++ b/drupal-src/patches/.gitattributes
@@ -1,3 +1,7 @@
 patches export-ignore
 vendor/bin export-ignore
+web/core/tests/**/* export-ignore
+web/core/modules/*/tests/**/* export-ignore
+web/core/themes/*/tests/**/* export-ignore
 web/sites/default/files/php export-ignore
+web/core/assets export-ignore


### PR DESCRIPTION
part of #19

with [`c20e10f` (#20)](https://github.com/mglaman/wasm-drupal/pull/20/commits/c20e10fb174d13ee5f0cb9fcf4e9da9b6b6eb692), the size is 20M